### PR TITLE
Stop excesselt from exploding when it finds an XML comment

### DIFF
--- a/lib/excesselt/stylesheet.rb
+++ b/lib/excesselt/stylesheet.rb
@@ -22,6 +22,7 @@ module Excesselt
     end
 
     def generate_element(element)
+      return '' if element.instance_of? Nokogiri::XML::Comment
       rule = rule_for(element)
       raise "Attempted to generate #{self.name} with parents #{self.parents.inspect} but no rule was found." unless rule
       rule.generate(builder)

--- a/spec/excesselt_spec.rb
+++ b/spec/excesselt_spec.rb
@@ -45,6 +45,18 @@ describe "excesselt" do
       EXPECTED
       @stylesheet.transform(xml).should match_the_dom_of(expected)
     end
+
+    it "should ignore comments" do
+      xml = <<-XML
+        <parent>
+          <!-- Ignore me -->
+        </parent>
+      XML
+      expected = <<-EXPECTED
+        <p style="parent_content"/>
+      EXPECTED
+      @stylesheet.transform(xml).should match_the_dom_of(expected)
+    end
     
     it "should transform a goodbye document according to a stylesheet" do
       xml = <<-XML


### PR DESCRIPTION
For extra credit, modify this to allow user to process comments like elements.
